### PR TITLE
Update to spec version af1e463

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jtd"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Rust implementation of JSON Type Definition"
 authors = ["JSON Type Definition Contributors"]
 edition = "2018"

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -192,12 +192,6 @@ impl Vm {
                         self.pop_schema_token();
 
                         if !*additional {
-                            self.push_schema_token(if *has_required {
-                                "properties"
-                            } else {
-                                "optionalProperties"
-                            });
-
                             for name in obj.keys() {
                                 if parent_tag != Some(name)
                                     && !required.contains_key(name)
@@ -208,8 +202,6 @@ impl Vm {
                                     self.pop_instance_token();
                                 }
                             }
-
-                            self.pop_schema_token();
                         }
                     } else {
                         self.push_schema_token(if *has_required {


### PR DESCRIPTION
This PR fixes the schema paths reported for unexpected additional properties, for schemas of the properties form.

It also bumps this package to version 0.1.1.