### PR TITLE
Update to latest version of spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jtd"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Rust implementation of JSON Type Definition"
 authors = ["JSON Type Definition Contributors"]
 edition = "2018"

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -24,6 +24,7 @@ pub enum ValidateError {
     NonRootDefinitions,
     EmptyEnum,
     RepeatedProperty(String),
+    MappingNullable,
     MappingNotPropertiesForm,
 }
 
@@ -139,8 +140,15 @@ impl Schema {
 
                     match &schema.form {
                         form::Form::Properties(form::Properties {
-                            required, optional, ..
+                            required,
+                            optional,
+                            nullable,
+                            ..
                         }) => {
+                            if *nullable {
+                                return Err(ValidateError::MappingNullable);
+                            }
+
                             if required.contains_key(discriminator)
                                 || optional.contains_key(discriminator)
                             {


### PR DESCRIPTION
This PR bumps the version of the spec used to test against, and adds support for disallowing nullable mapping values.