### PR TITLE
Add an impl of From<schema::Schema> for serde::Schema

### DIFF
--- a/src/form.rs
+++ b/src/form.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::str::FromStr;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum Form {
     Empty,
@@ -22,21 +22,21 @@ impl Default for Form {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Ref {
     pub nullable: bool,
     pub definition: String,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Type {
     pub nullable: bool,
     pub type_value: TypeValue,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TypeValue {
     Boolean,
@@ -73,21 +73,21 @@ impl FromStr for TypeValue {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Enum {
     pub nullable: bool,
     pub values: HashSet<String>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Elements {
     pub nullable: bool,
     pub schema: Box<Schema>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Properties {
     pub nullable: bool,
@@ -97,14 +97,14 @@ pub struct Properties {
     pub has_required: bool,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Values {
     pub nullable: bool,
     pub schema: Box<Schema>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Discriminator {
     pub nullable: bool,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Schema {
     pub definitions: HashMap<String, Schema>,
     pub form: form::Form,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,8 +1,9 @@
+use crate::schema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct Schema {
@@ -45,6 +46,127 @@ impl arbitrary::Arbitrary for Schema {
             // So we'll always have metadata be None.
             metadata: None,
         })
+    }
+}
+
+impl From<schema::Schema> for Schema {
+    fn from(schema: schema::Schema) -> Schema {
+        use crate::form;
+
+        let mut out = Schema::default();
+
+        if !schema.definitions.is_empty() {
+            out.definitions = Some(
+                schema
+                    .definitions
+                    .into_iter()
+                    .map(|(k, v)| (k, v.into()))
+                    .collect(),
+            );
+        }
+
+        match schema.form {
+            form::Form::Empty => {}
+            form::Form::Ref(form::Ref {
+                nullable,
+                definition,
+            }) => {
+                if nullable {
+                    out.nullable = Some(true);
+                }
+
+                out.ref_ = Some(definition);
+            }
+            form::Form::Type(form::Type {
+                nullable,
+                type_value,
+            }) => {
+                if nullable {
+                    out.nullable = Some(true);
+                }
+
+                out.type_ = Some(
+                    match type_value {
+                        form::TypeValue::Boolean => "boolean",
+                        form::TypeValue::Float32 => "float32",
+                        form::TypeValue::Float64 => "float64",
+                        form::TypeValue::Int8 => "int8",
+                        form::TypeValue::Uint8 => "uint8",
+                        form::TypeValue::Int16 => "int16",
+                        form::TypeValue::Uint16 => "uint16",
+                        form::TypeValue::Int32 => "int32",
+                        form::TypeValue::Uint32 => "uint32",
+                        form::TypeValue::String => "string",
+                        form::TypeValue::Timestamp => "timestamp",
+                    }
+                    .to_owned(),
+                )
+            }
+            form::Form::Enum(form::Enum { nullable, values }) => {
+                if nullable {
+                    out.nullable = Some(true);
+                }
+
+                out.enum_ = Some(values.into_iter().collect());
+            }
+            form::Form::Elements(form::Elements { nullable, schema }) => {
+                if nullable {
+                    out.nullable = Some(true);
+                }
+
+                out.elements = Some(Box::new((*schema).into()));
+            }
+            form::Form::Properties(form::Properties {
+                nullable,
+                required,
+                optional,
+                additional,
+                has_required,
+            }) => {
+                if nullable {
+                    out.nullable = Some(true);
+                }
+
+                if has_required {
+                    out.properties =
+                        Some(required.into_iter().map(|(k, v)| (k, v.into())).collect());
+                }
+
+                if !optional.is_empty() {
+                    out.optional_properties =
+                        Some(optional.into_iter().map(|(k, v)| (k, v.into())).collect());
+                }
+
+                if additional {
+                    out.additional_properties = Some(true);
+                }
+            }
+            form::Form::Values(form::Values { nullable, schema }) => {
+                if nullable {
+                    out.nullable = Some(true);
+                }
+
+                out.values = Some(Box::new((*schema).into()));
+            }
+            form::Form::Discriminator(form::Discriminator {
+                nullable,
+                discriminator,
+                mapping,
+            }) => {
+                if nullable {
+                    out.nullable = Some(true);
+                }
+
+                out.discriminator = Some(discriminator);
+                out.mapping = Some(mapping.into_iter().map(|(k, v)| (k, v.into())).collect());
+            }
+        }
+
+        if !schema.metadata.is_empty() {
+            out.metadata = Some(schema.metadata);
+        }
+
+        out
     }
 }
 
@@ -193,5 +315,108 @@ mod tests {
             }))
             .unwrap()
         );
+    }
+
+    #[test]
+    fn from_empty() {
+        assert_roundtrip_try_into_from(json!({}));
+    }
+
+    #[test]
+    fn from_ref() {
+        assert_roundtrip_try_into_from(json!({"ref": "foo"}));
+        assert_roundtrip_try_into_from(json!({"ref": "foo", "nullable": true}));
+    }
+
+    #[test]
+    fn from_type() {
+        assert_roundtrip_try_into_from(json!({"type": "boolean"}));
+        assert_roundtrip_try_into_from(json!({"type": "boolean", "nullable": true}));
+
+        assert_roundtrip_try_into_from(json!({"type": "int8"}));
+        assert_roundtrip_try_into_from(json!({"type": "uint8"}));
+        assert_roundtrip_try_into_from(json!({"type": "int16"}));
+        assert_roundtrip_try_into_from(json!({"type": "uint16"}));
+        assert_roundtrip_try_into_from(json!({"type": "int32"}));
+        assert_roundtrip_try_into_from(json!({"type": "uint32"}));
+        assert_roundtrip_try_into_from(json!({"type": "string"}));
+        assert_roundtrip_try_into_from(json!({"type": "timestamp"}));
+    }
+
+    #[test]
+    fn from_enum() {
+        assert_roundtrip_try_into_from(json!({ "enum": ["foo"] }));
+        assert_roundtrip_try_into_from(json!({ "enum": ["foo"], "nullable": true }));
+    }
+
+    #[test]
+    fn from_elements() {
+        assert_roundtrip_try_into_from(json!({ "elements": { "type": "boolean" } }));
+        assert_roundtrip_try_into_from(
+            json!({ "elements": { "type": "boolean" }, "nullable": true }),
+        );
+    }
+
+    #[test]
+    fn from_properties() {
+        assert_roundtrip_try_into_from(json!({ "properties": { "foo": { "type": "boolean" }}}));
+        assert_roundtrip_try_into_from(
+            json!({ "optionalProperties": { "foo": { "type": "boolean" }}}),
+        );
+        assert_roundtrip_try_into_from(
+            json!({ "properties": { "foo": { "type": "boolean" }}, "nullable": true }),
+        );
+        assert_roundtrip_try_into_from(
+            json!({ "optionalProperties": { "foo": { "type": "boolean" }}, "nullable": true }),
+        );
+        assert_roundtrip_try_into_from(json!({
+            "properties": { "foo": { "type": "boolean" }},
+            "optionalProperties": { "bar": { "type": "boolean" }},
+        }));
+        assert_roundtrip_try_into_from(json!({
+            "properties": { "foo": { "type": "boolean" }},
+            "optionalProperties": { "bar": { "type": "boolean" }},
+            "nullable": true,
+        }));
+    }
+
+    #[test]
+    fn from_values() {
+        assert_roundtrip_try_into_from(json!({ "values": { "type": "boolean" } }));
+        assert_roundtrip_try_into_from(
+            json!({ "values": { "type": "boolean" }, "nullable": true }),
+        );
+    }
+
+    #[test]
+    fn from_discriminator() {
+        assert_roundtrip_try_into_from(json!({
+            "discriminator": "foo",
+            "mapping": {
+                "foo": {
+                    "properties": { "bar": { "type": "boolean" }},
+                },
+            },
+        }));
+
+        assert_roundtrip_try_into_from(json!({
+            "discriminator": "foo",
+            "mapping": {
+                "foo": {
+                    "properties": { "bar": { "type": "boolean" }}
+                }
+            },
+            "nullable": true,
+        }));
+    }
+
+    fn assert_roundtrip_try_into_from(json: serde_json::Value) {
+        use crate::schema;
+        use std::convert::TryInto;
+
+        let serde_schema: super::Schema = serde_json::from_value(json).unwrap();
+        let schema: schema::Schema = serde_schema.clone().try_into().unwrap();
+
+        assert_eq!(serde_schema, schema.into());
     }
 }


### PR DESCRIPTION
This PR adds an implementation of From that lets you convert from the internal representation of a schema to the Serde-friendly one. This is tested by round-tripping from JSON into serde::Schema, then schema::Schema, then back to serde::Schema.

This PR also adds an implementation of `Clone` for schema::Schema, because it can be derived and Clone is always useful.