### PR TITLE
Skip serializing None properties of serde::Schema

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -7,18 +7,43 @@ use std::collections::HashMap;
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct Schema {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub definitions: Option<HashMap<String, Schema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ref_: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub type_: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enum_: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub elements: Option<Box<Schema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<HashMap<String, Schema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub optional_properties: Option<HashMap<String, Schema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_properties: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub values: Option<Box<Schema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub discriminator: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mapping: Option<HashMap<String, Schema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, Value>>,
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -200,6 +200,19 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn serialize_partial() {
+        // Fields are None by default. These shouldn't be serialized.
+        assert_eq!(
+            "{\"ref\":\"foo\"}",
+            serde_json::to_string(&super::Schema {
+                ref_: Some("foo".to_owned()),
+                ..Default::default()
+            })
+            .unwrap()
+        );
+    }
+
+    #[test]
     fn parse_empty() {
         assert_eq!(
             super::Schema::default(),


### PR DESCRIPTION
This PR has serde skip serializing any `None`-fields of `serde::Schema`. Otherwise, the fields are going to be serialized as `null`, resulting in incorrect schemas.