### PR TITLE
Use BTreeMap instead of HashMap for deterministic ordering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jtd"
-version = "0.1.4"
+version = "0.2.0"
 description = "A Rust implementation of JSON Type Definition"
 authors = ["JSON Type Definition Contributors"]
 edition = "2018"

--- a/src/form.rs
+++ b/src/form.rs
@@ -1,6 +1,6 @@
 use crate::schema::Schema;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -77,7 +77,7 @@ impl FromStr for TypeValue {
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Enum {
     pub nullable: bool,
-    pub values: HashSet<String>,
+    pub values: BTreeSet<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -91,8 +91,8 @@ pub struct Elements {
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Properties {
     pub nullable: bool,
-    pub required: HashMap<String, Schema>,
-    pub optional: HashMap<String, Schema>,
+    pub required: BTreeMap<String, Schema>,
+    pub optional: BTreeMap<String, Schema>,
     pub additional: bool,
     pub has_required: bool,
 }
@@ -109,7 +109,7 @@ pub struct Values {
 pub struct Discriminator {
     pub nullable: bool,
     pub discriminator: String,
-    pub mapping: HashMap<String, Schema>,
+    pub mapping: BTreeMap<String, Schema>,
 }
 
 #[cfg(test)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,14 +1,14 @@
 use crate::form;
 use crate::serde;
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::{TryFrom, TryInto};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Schema {
-    pub definitions: HashMap<String, Schema>,
+    pub definitions: BTreeMap<String, Schema>,
     pub form: form::Form,
-    pub metadata: HashMap<String, Value>,
+    pub metadata: BTreeMap<String, Value>,
 }
 
 #[cfg(feature = "fuzz")]
@@ -23,7 +23,7 @@ impl arbitrary::Arbitrary for Schema {
             // manipulating arbitrary JSON values.
             //
             // So we'll always have metadata be None.
-            metadata: HashMap::new(),
+            metadata: BTreeMap::new(),
         })
     }
 }
@@ -205,7 +205,7 @@ impl TryFrom<serde::Schema> for Schema {
             return Err(SerdeConvertError::InvalidForm);
         }
 
-        let mut definitions = HashMap::new();
+        let mut definitions = BTreeMap::new();
         for (name, sub_schema) in schema.definitions.unwrap_or_default() {
             definitions.insert(name, sub_schema.try_into()?);
         }
@@ -235,7 +235,7 @@ impl TryFrom<serde::Schema> for Schema {
         }
 
         if let Some(enum_) = schema.enum_ {
-            let mut values = HashSet::new();
+            let mut values = BTreeSet::new();
             for val in enum_ {
                 if values.contains(&val) {
                     return Err(SerdeConvertError::DuplicatedEnumValue(val));
@@ -268,12 +268,12 @@ impl TryFrom<serde::Schema> for Schema {
         if schema.properties.is_some() || schema.optional_properties.is_some() {
             let has_required = schema.properties.is_some();
 
-            let mut required = HashMap::new();
+            let mut required = BTreeMap::new();
             for (name, sub_schema) in schema.properties.unwrap_or_default() {
                 required.insert(name, sub_schema.try_into()?);
             }
 
-            let mut optional = HashMap::new();
+            let mut optional = BTreeMap::new();
             for (name, sub_schema) in schema.optional_properties.unwrap_or_default() {
                 optional.insert(name, sub_schema.try_into()?);
             }
@@ -303,7 +303,7 @@ impl TryFrom<serde::Schema> for Schema {
         }
 
         if let Some(discriminator) = schema.discriminator {
-            let mut mapping = HashMap::new();
+            let mut mapping = BTreeMap::new();
             for (name, sub_schema) in schema.mapping.unwrap() {
                 mapping.insert(name, sub_schema.try_into()?);
             }
@@ -605,7 +605,7 @@ mod tests {
                     required: vec![("foo".to_owned(), Default::default())]
                         .into_iter()
                         .collect(),
-                    optional: HashMap::new(),
+                    optional: BTreeMap::new(),
                     additional: false,
                     has_required: true,
                 }),
@@ -627,7 +627,7 @@ mod tests {
             Ok(Schema {
                 form: form::Form::Properties(form::Properties {
                     nullable: false,
-                    required: HashMap::new(),
+                    required: BTreeMap::new(),
                     optional: vec![("foo".to_owned(), Default::default())]
                         .into_iter()
                         .collect(),
@@ -909,7 +909,7 @@ mod tests {
 
     #[test]
     fn spec_invalid_schemas_suite() {
-        let test_cases: HashMap<String, Value> = serde_json::from_str(include_str!(
+        let test_cases: BTreeMap<String, Value> = serde_json::from_str(include_str!(
             "../json-typedef-spec/tests/invalid_schemas.json"
         ))
         .unwrap();

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,14 +1,14 @@
 use crate::schema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct Schema {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub definitions: Option<HashMap<String, Schema>>,
+    pub definitions: Option<BTreeMap<String, Schema>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
@@ -26,10 +26,10 @@ pub struct Schema {
     pub elements: Option<Box<Schema>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub properties: Option<HashMap<String, Schema>>,
+    pub properties: Option<BTreeMap<String, Schema>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_properties: Option<HashMap<String, Schema>>,
+    pub optional_properties: Option<BTreeMap<String, Schema>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_properties: Option<bool>,
@@ -41,10 +41,10 @@ pub struct Schema {
     pub discriminator: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mapping: Option<HashMap<String, Schema>>,
+    pub mapping: Option<BTreeMap<String, Schema>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<HashMap<String, Value>>,
+    pub metadata: Option<BTreeMap<String, Value>>,
 }
 
 #[cfg(feature = "fuzz")]

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -333,7 +333,7 @@ mod tests {
     use crate::SerdeSchema;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::{BTreeMap, BTreeSet};
     use std::convert::TryInto;
 
     #[test]
@@ -391,14 +391,14 @@ mod tests {
             errors: Vec<TestCaseError>,
         }
 
-        #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+        #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug)]
         #[serde(rename_all = "camelCase")]
         struct TestCaseError {
             instance_path: Vec<String>,
             schema_path: Vec<String>,
         }
 
-        let test_cases: HashMap<String, TestCase> =
+        let test_cases: BTreeMap<String, TestCase> =
             serde_json::from_str(include_str!("../json-typedef-spec/tests/validation.json"))
                 .unwrap();
 
@@ -413,7 +413,7 @@ mod tests {
                 max_errors: None,
             };
 
-            let errors: HashSet<_> = validator
+            let errors: BTreeSet<_> = validator
                 .validate(&schema, &test_case.instance)
                 .expect(&format!("validating: {}", name))
                 .into_iter()
@@ -424,7 +424,7 @@ mod tests {
                 .collect();
 
             assert_eq!(
-                test_case.errors.into_iter().collect::<HashSet<_>>(),
+                test_case.errors.into_iter().collect::<BTreeSet<_>>(),
                 errors,
                 "wrong set of errors returned for test case: {}",
                 name


### PR DESCRIPTION
This PR changes `Hash{Map,Set}` to `BTree{Map,Set}` so that tooling which is built on top of this crate does not need to reimplement its own ordering stuff. It turns out a lot of tooling would be well-served by getting deterministic ordering out of schemas, because it makes it easier to build idempotent tools.