### PR TITLE
Fix validate's checking of non-root definitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jtd"
-version = "0.2.0"
+version = "0.2.1"
 description = "A Rust implementation of JSON Type Definition"
 authors = ["JSON Type Definition Contributors"]
 edition = "2018"

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -403,10 +403,12 @@ mod tests {
                 .unwrap();
 
         for (name, test_case) in test_cases {
-            let schema = test_case
+            let schema: Schema = test_case
                 .schema
                 .try_into()
                 .expect(&format!("parsing schema: {}", name));
+
+            schema.validate().expect(&format!("validating schema: {}", name));
 
             let validator = Validator {
                 max_depth: None,


### PR DESCRIPTION
The current implementation of `Schema::validate` has two problems:

1. It does not detect validation problems in definitions, because it does not recursively validate each of them.
2. It wrongly reports root definitions as being illegal non-root definitions.

This PR fixes both by first adding a test to the validation test suite that makes sure each schema from that test suite is considered valid. This reveals problem (2). Fixing (2) forces us to fix (1) as well.