### PR TITLE
Add Schema::into_serde_schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jtd"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Rust implementation of JSON Type Definition"
 authors = ["JSON Type Definition Contributors"]
 edition = "2018"


### PR DESCRIPTION
This PR adds `Schema::into_serde_schema`, an inverse to `from_serde_schema`.

This PR continues to deliberately avoid using the stdlib's Into/From traits to achieve this, because 1) it's easier to add support for that than to remove it, and 2) it seems to be relatively unusual to have such a business-logic-heavy sort of conversion be done via Into/From implementations.