### PR TITLE
remove chrono default features to avoid time v1 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", features = ["std", "clock", "wasmbind"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"


### PR DESCRIPTION
This removes the dependency on time v1, which is deprecated and was kept for compatibility only